### PR TITLE
[sc-621] - Chore/spread component props

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -30,6 +30,7 @@
     "react": "^17.0.2"
   },
   "dependencies": {
-    "@owlui/typings": "^0.0.1"
+    "@owlui/typings": "^0.0.1",
+    "@owlui/utils": "^0.0.19"
   }
 }

--- a/packages/icons/src/Default/Default.tsx
+++ b/packages/icons/src/Default/Default.tsx
@@ -38,7 +38,7 @@ export const Component = (props: IconsDefaultProps) => {
         ],
       },
     },
-    ['theme', 'appearance']
+    ['icon', 'prefix', 'display', 'theme', 'appearance', 'size']
   );
 
   return <span {...locals}>{icon}</span>;

--- a/packages/icons/src/Default/Default.tsx
+++ b/packages/icons/src/Default/Default.tsx
@@ -1,62 +1,47 @@
 import * as React from 'react';
 import { IconsDefaultProps } from './Default.types';
 import * as styleMod from './styles.module.scss';
-
-const baseClass = 'icons';
+import { createLocalProps } from '@owlui/utils';
 
 export const Component = (props: IconsDefaultProps) => {
-  const { className, style, 'aria-hidden': ariaHidden } = props;
-
-  const modulePrefix = props.prefix;
+  let baseClass = 'icons';
   const icon = props.icon;
   const display = props.display || 'Filled';
-  const theme = props.theme || '';
-  const appearance = props.appearance || '';
-  const size = props.size || '';
-
-  const styleLocal = {
-    base: styleMod[baseClass],
-    theme: styleMod[`${baseClass}Theme${theme}`],
-    appearance: styleMod[`${baseClass}Theme${theme}${appearance}`],
-    size: '',
-  };
-
-  if (size) {
-    styleLocal.size = styleMod[`${baseClass}Size${size}`];
-  }
-
-  if (modulePrefix !== undefined && modulePrefix !== null) {
-    styleLocal.base = `${modulePrefix}-${styleLocal.base}`;
-    styleLocal.theme = `${modulePrefix}-${styleLocal.theme}`;
-    styleLocal.appearance = `${modulePrefix}-${styleLocal.appearance}`;
-
-    if (size) {
-      styleLocal.size = `${modulePrefix}-${styleLocal.size}`;
-    }
-  }
+  const prefix = props.prefix || '';
 
   switch (display) {
     case 'Outlined':
-      styleLocal.base += '-outlined';
+      baseClass += 'Outlined';
       break;
   }
 
-  return (
-    <span
-      style={style}
-      className={[
-        className?.trim(),
-        styleLocal.base,
-        styleLocal.theme,
-        styleLocal.appearance,
-        styleLocal.size,
-      ].join(' ')}
-      role="img"
-      aria-hidden={ariaHidden}
-    >
-      {icon}
-    </span>
+  const locals = createLocalProps(
+    props,
+    {
+      module: styleMod,
+      classes: {
+        base: baseClass,
+        prefix: prefix,
+        optionals: [
+          {
+            fields: ['theme'],
+            value: 'Theme',
+          },
+          {
+            fields: ['theme', 'appearance'],
+            value: 'Theme',
+          },
+          {
+            fields: ['size'],
+            value: 'Size',
+          },
+        ],
+      },
+    },
+    ['theme', 'appearance']
   );
+
+  return <span {...locals}>{icon}</span>;
 };
 
 export default {

--- a/packages/icons/src/Default/stories/Default-appearance.stories.tsx
+++ b/packages/icons/src/Default/stories/Default-appearance.stories.tsx
@@ -1,9 +1,9 @@
 export const appearance = {
-  options: ['', 'Primary', 'Alt'],
+  options: ['Primary', 'Alt'],
   control: {
     type: 'select',
   },
-  defaultValue: '',
+  defaultValue: 'Primary',
 };
 
 export default {

--- a/packages/icons/src/Default/stories/Default-display.stories.tsx
+++ b/packages/icons/src/Default/stories/Default-display.stories.tsx
@@ -1,9 +1,9 @@
 export const display = {
-  options: ['', 'Filled', 'Outlined'],
+  options: ['Default', 'Outlined'],
   control: {
     type: 'select',
   },
-  defaultValue: '',
+  defaultValue: 'Default',
 };
 
 export default {

--- a/packages/icons/src/Default/stories/Default-display.stories.tsx
+++ b/packages/icons/src/Default/stories/Default-display.stories.tsx
@@ -1,9 +1,9 @@
 export const display = {
-  options: ['Default', 'Outlined'],
+  options: ['Filled', 'Outlined'],
   control: {
     type: 'select',
   },
-  defaultValue: 'Default',
+  defaultValue: 'Filled',
 };
 
 export default {

--- a/packages/icons/src/Default/stories/Default-index.stories.tsx
+++ b/packages/icons/src/Default/stories/Default-index.stories.tsx
@@ -13,9 +13,9 @@ export const Default = (args: IconsDefaultProps) => <Icons {...args} />;
 Default.args = {
   icon: icon.defaultValue,
   display: display.defaultValue,
-  appearance: '',
-  size: 'Lg',
-  theme: 'Default',
+  appearance: appearance.defaultValue,
+  size: size.defaultValue,
+  theme: theme.defaultValue,
 };
 
 Default.argTypes = {

--- a/packages/icons/src/Default/stories/Default-size.stories.tsx
+++ b/packages/icons/src/Default/stories/Default-size.stories.tsx
@@ -1,9 +1,9 @@
 export const size = {
-  options: ['', 'Lg', 'Md', 'Sm', 'Xs', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6'],
+  options: ['Lg', 'Md', 'Sm', 'Xs', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6'],
   control: {
     type: 'select',
   },
-  defaultValue: '',
+  defaultValue: 'Md',
 };
 
 export default {

--- a/packages/icons/src/Default/styles.module.scss
+++ b/packages/icons/src/Default/styles.module.scss
@@ -2,7 +2,6 @@
 
 .icons,
 .icons-outlined {
-  font-size: theme.$owl-sys-typeface-body-size;
   color: theme.$owl-sys-color-on-light;
 
   &--theme {

--- a/packages/theme/src/global/_font-icons.scss
+++ b/packages/theme/src/global/_font-icons.scss
@@ -48,14 +48,23 @@
   font-family: 'Material Icons Outlined';
   font-weight: normal;
   font-style: normal;
-  font-size: $owl-sys-typeface-body-size;
-  line-height: 1;
-  letter-spacing: normal;
-  text-transform: none;
+  /* Preferred icon size */
   display: inline-block;
-  white-space: nowrap;
+  line-height: 1;
+  text-transform: none;
+  letter-spacing: normal;
   word-wrap: normal;
+  white-space: nowrap;
   direction: ltr;
-  -webkit-font-feature-settings: 'liga';
+
+  /* Support for all WebKit browsers. */
   -webkit-font-smoothing: antialiased;
+  /* Support for Safari and Chrome. */
+  text-rendering: optimizeLegibility;
+
+  /* Support for Firefox. */
+  -moz-osx-font-smoothing: grayscale;
+
+  /* Support for IE. */
+  font-feature-settings: 'liga';
 }

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -9,3 +9,27 @@ export type CSSModClass = {
   styles: stylesProp;
   baseClass: string;
 };
+
+export type localProps = {
+  // [key: string]: unknown;
+  props: object;
+  styles: {
+    module: stylesProp;
+    classes: {
+      base: string;
+      optionals: Array<{ fields: string[]; value: string }>;
+    };
+  };
+  removables: string[];
+};
+
+export type createLocalPropsProps = Record<string, string>;
+
+export type createStyles = {
+  module: stylesProp;
+  classes: {
+    base: string;
+    prefix: string;
+    optionals: Array<{ fields: string[]; value: string }>;
+  };
+};

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -4,28 +4,17 @@ export type localProp = React.HTMLAttributes<HTMLElement>;
 
 export type stylesProp = Record<string, string>;
 
-export type CSSModClass = {
+export interface CSSModClass {
   localProps: localProp;
   styles: stylesProp;
   baseClass: string;
-};
+}
 
-export type localProps = {
-  // [key: string]: unknown;
-  props: object;
-  styles: {
-    module: stylesProp;
-    classes: {
-      base: string;
-      optionals: Array<{ fields: string[]; value: string }>;
-    };
-  };
-  removables: string[];
-};
+export interface localInnerProps {
+  [key: string]: unknown;
+}
 
-export type createLocalPropsProps = Record<string, string>;
-
-export type createStyles = {
+export type localStyles = {
   module: stylesProp;
   classes: {
     base: string;

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -1,4 +1,10 @@
-import { CSSModClass, stylesProp, localProp } from './types';
+import {
+  CSSModClass,
+  stylesProp,
+  localProp,
+  createStyles,
+  createLocalPropsProps,
+} from './types';
 
 export const hasProp = (obj: object, prop: string) => {
   return Object.prototype.hasOwnProperty.call(obj, prop);
@@ -31,9 +37,54 @@ export const findModClass = (styles: stylesProp, baseClass: string) => {
   };
 };
 
+export const createLocalProps = (
+  props: object,
+  styles: createStyles,
+  removables: string[]
+): object => {
+  const getClassName = findModClass(styles.module, styles.classes.base);
+  const localClassName = [styles.module[styles.classes.base]];
+  const localProps: createLocalPropsProps = { ...props };
+  const classPrefix = styles.classes.prefix;
+
+  styles.classes.optionals.forEach(option => {
+    let classTemp = option.value;
+    let propValue = '';
+
+    option.fields.forEach(field => {
+      // as keyof type of {} is used to get the key type of an unknown property
+      propValue = props[field as keyof typeof props] || '';
+      classTemp += propValue;
+    });
+
+    if (classTemp) {
+      const classValue = getClassName(classTemp);
+
+      if (classValue) {
+        localClassName.push(
+          classPrefix ? `${classPrefix}-${classValue}` : classValue
+        );
+      }
+    }
+  });
+
+  if (removables) removables.forEach(key => delete localProps[key]);
+
+  const classNames: string | string[] = localProps.className
+    ? localProps.className + ' ' + localClassName
+    : localClassName;
+
+  if (Array.isArray(classNames)) {
+    localProps.className = classNames.join(' ');
+  }
+
+  return localProps;
+};
+
 export default {
   hasProp,
   cleanCopy,
   getCssModClass,
   findModClass,
+  createLocalProps,
 };

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -2,8 +2,8 @@ import {
   CSSModClass,
   stylesProp,
   localProp,
-  createStyles,
-  createLocalPropsProps,
+  localStyles,
+  localInnerProps,
 } from './types';
 
 export const hasProp = (obj: object, prop: string) => {
@@ -39,12 +39,12 @@ export const findModClass = (styles: stylesProp, baseClass: string) => {
 
 export const createLocalProps = (
   props: object,
-  styles: createStyles,
+  styles: localStyles,
   removables: string[]
 ): object => {
   const getClassName = findModClass(styles.module, styles.classes.base);
   const localClassName = [styles.module[styles.classes.base]];
-  const localProps: createLocalPropsProps = { ...props };
+  const localProps: localInnerProps = { ...props };
   const classPrefix = styles.classes.prefix;
 
   styles.classes.optionals.forEach(option => {

--- a/scripts/pipeline/assets/MaterialIcons-Outlined.scss
+++ b/scripts/pipeline/assets/MaterialIcons-Outlined.scss
@@ -9,14 +9,23 @@
   font-family: 'Material Icons Outlined';
   font-weight: normal;
   font-style: normal;
-  font-size: $owl-sys-typeface-body-size;
-  line-height: 1;
-  letter-spacing: normal;
-  text-transform: none;
+  /* Preferred icon size */
   display: inline-block;
-  white-space: nowrap;
+  line-height: 1;
+  text-transform: none;
+  letter-spacing: normal;
   word-wrap: normal;
+  white-space: nowrap;
   direction: ltr;
-  -webkit-font-feature-settings: 'liga';
+
+  /* Support for all WebKit browsers. */
   -webkit-font-smoothing: antialiased;
+  /* Support for Safari and Chrome. */
+  text-rendering: optimizeLegibility;
+
+  /* Support for Firefox. */
+  -moz-osx-font-smoothing: grayscale;
+
+  /* Support for IE. */
+  font-feature-settings: 'liga';
 }


### PR DESCRIPTION
### Short summary

Created a new utility method that will be used around the components to:
- filter unneeded props coming from the component declaration, such as, appearance and size, otherwise, they will be added as properties to the HTML elements;
- create the element classes based on the CSS module
- spread the props in the rendered element

**Important:**
- Only the Icon component has been updated, the other ones will be updated once we have the new method reviewed.
- Font icon files have been updated to remove the font size that was overwriting the modules' styles.
- The scripts templates will be updated once we have the new method good to go.

---

### Test steps

1. Run `yarn build:dist` to build the utilities package
2. Run `yarn start:storybook` and test **only** the Icon component. No changes were made to styles or markup so it should work just the same it works on the `main` branch.
