### PR TITLE
UPDATE [sc-836] - fixed the pathing for loading and serving static assets

### DIFF
--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -2,7 +2,12 @@ const path = require('path');
 
 module.exports = {
   "framework": "@storybook/react",
-  "staticDirs": ['../packages/theme/src/global'],
+  "staticDirs": [
+    {
+      from: '../packages/theme/src/assets',
+      to: '/~@owlui/theme/src/assets'
+    }
+  ],
   "stories": ["../packages/**/*.stories.mdx", "../packages/**/*.stories.@(js|jsx|ts|tsx)"],
   "typescript": {
     "reactDocgen": "",
@@ -62,7 +67,18 @@ module.exports = {
       loader: 'sass-loader',
       options: {
         sourceMap: true,
-        implementation: require('sass')
+        implementation: require('sass'),
+        sassOptions: {
+          includePaths: [
+            "./",
+            "../",
+            "../../node_modules/",
+            "../../node_modules/@owlui/theme/src/global/",
+            "../../node_modules/@owlui/theme/src/assets/",
+            "../@owlui/theme/src/global/",
+            "./node_modules/"
+          ]
+        }
       }
     };
     const fileLoader = {


### PR DESCRIPTION
### Short summary

- the last update broke the pathing for storybook being able to serve static assets
- updated the storybook webpack config to fix the issue

---

### Test steps

1. `yarn start:storybook`
2. no 404 errors in console related to static assets
