### PR TITLE
[sc-918] - Bug/RGB Color Values

### DIFF
--- a/theme/src/global/_variables.scss
+++ b/theme/src/global/_variables.scss
@@ -4,8 +4,8 @@
 @use '@owlui/design/dist/styledictionary/scss' as *;
 
 @function toRGB($color) {
-  @return 'rgb(' + color.red($color) + ', ' + color.green($color) + ', ' +
-    color.blue($color) + ')';
+  @return color.red($color) + ', ' + color.green($color) + ', ' +
+    color.blue($color);
 }
 
 :root {


### PR DESCRIPTION
### Short summary
Remove the text that wraps the return of the function `toRGB` from the Theme package.

The function returned the RGB values wrapped in the text `rgb()` and the browser is not able to convert them to real RGB values.

```
//before
--bs-secondary-rgb: rgb(108, 117, 125);

//after
--bs-secondary-rgb: 108, 117, 125;
```
