### PR TITLE
[sc-888] - Chore/Add prefix to bootstrap utility classes

### DIFF
--- a/utils/src/types.ts
+++ b/utils/src/types.ts
@@ -20,5 +20,6 @@ export type localStyles = {
     base: string;
     prefix: string;
     optionals: Array<{ fields: string[]; value: string }>;
+    bsProps?: string[];
   };
 };

--- a/utils/src/utils.ts
+++ b/utils/src/utils.ts
@@ -50,6 +50,8 @@ export const createLocalProps = (
   const getGlobalClasses = findModClass(styleMod);
   const localClassName = [styles.module[styles.classes.base]];
   const localProps: localInnerProps = { ...props };
+  const bsProps = styles.classes.bsProps;
+  const bsPropClassesPrefix = 'owlui';
   const classPrefix = styles.classes.prefix;
 
   styles.classes.optionals.forEach(option => {
@@ -76,6 +78,20 @@ export const createLocalProps = (
       }
     }
   });
+
+  if (bsProps) {
+    bsProps.forEach(bsProp => {
+      localClassName.push(
+        classPrefix
+          ? `${classPrefix}-${bsPropClassesPrefix}-${bsProp}-${
+              props[bsProp as keyof typeof props]
+            }`
+          : `${bsPropClassesPrefix}-${bsProp}-${
+              props[bsProp as keyof typeof props]
+            }`
+      );
+    });
+  }
 
   if (removables) removables.forEach(key => delete localProps[key]);
 

--- a/utils/src/utils.ts
+++ b/utils/src/utils.ts
@@ -81,15 +81,17 @@ export const createLocalProps = (
 
   if (bsProps) {
     bsProps.forEach(bsProp => {
-      localClassName.push(
-        classPrefix
-          ? `${classPrefix}-${bsPropClassesPrefix}-${bsProp}-${
-              props[bsProp as keyof typeof props]
-            }`
-          : `${bsPropClassesPrefix}-${bsProp}-${
-              props[bsProp as keyof typeof props]
-            }`
-      );
+      if (props[bsProp as keyof typeof props]) {
+        localClassName.push(
+          classPrefix
+            ? `${classPrefix}-${bsPropClassesPrefix}-${String(bsProp)}-${
+                props[bsProp as keyof typeof props]
+              }`
+            : `${bsPropClassesPrefix}-${String(bsProp)}-${
+                props[bsProp as keyof typeof props]
+              }`
+        );
+      }
     });
   }
 

--- a/utils/src/utils.ts
+++ b/utils/src/utils.ts
@@ -81,15 +81,13 @@ export const createLocalProps = (
 
   if (bsProps) {
     bsProps.forEach(bsProp => {
-      if (props[bsProp as keyof typeof props]) {
+      const bsPropKey = props[bsProp as keyof typeof props];
+
+      if (bsPropKey) {
         localClassName.push(
           classPrefix
-            ? `${classPrefix}-${bsPropClassesPrefix}-${String(bsProp)}-${
-                props[bsProp as keyof typeof props]
-              }`
-            : `${bsPropClassesPrefix}-${String(bsProp)}-${
-                props[bsProp as keyof typeof props]
-              }`
+            ? `${classPrefix}-${bsPropClassesPrefix}-${bsProp}-${bsPropKey}`
+            : `${bsPropClassesPrefix}-${bsProp}-${bsPropKey}`
         );
       }
     });


### PR DESCRIPTION
### Short summary
Bootstrap adds classes based on component props, such as the `Card` border , background, and text color classes. These classes are not updated properly when a prefix is added to the component:

![image](https://user-images.githubusercontent.com/98419841/171941756-e667b9a0-a412-45a8-9a06-a09a1afce959.png)

The `createLocalProps` function has been updated to add a prefix to these utility classes. 

To add prefixes you should use the `bsProps` array in the `classes` object, this array accepts the name of the props:

```tsx
      classes: {
        base: baseClass,
        prefix: prefix,
        optionals: [
          {
            fields: ['theme'],
            value: 'theme',
          },
        ],
        bsProps: ['bg', 'border', 'text'],
      },
```

Updated classes:

![image](https://user-images.githubusercontent.com/98419841/171942253-a3ed79a6-d89f-458b-9630-27fd4d20784e.png)

If you need to remove the default Bootstrap classes you can use the `removables` array:

```tsx
    {
      ...
        bsProps: ['bg', 'border', 'text'],
      },
    },
    ['prefix', 'theme', 'appearance', 'bg', 'border', 'text']
```

And the unused classes will be removed:

![image](https://user-images.githubusercontent.com/98419841/171942697-1e24ef24-c2ac-4588-8a85-42f6886e9190.png)

**This will not update classes added during the run time, such as the dropdown `show` class discussed this week. 